### PR TITLE
Fix PHP notice

### DIFF
--- a/class-monthchunks.php
+++ b/class-monthchunks.php
@@ -122,7 +122,7 @@
 
         private function print_month ( $month, $year ) {
 
-            $tooltip = "title='" . esc_attr( $month_names[$month] . ' ' . $year ) . "'";
+            $tooltip = "title='" . esc_attr( $this->month_names[$month] . ' ' . $year ) . "'";
             $month_link = get_month_link( $year, $month );
             $month_text = esc_html( $this->month_codes[$month] );
 


### PR DESCRIPTION
Fixed the wrong month names reference in `print_month() `method of the `MonthChunks` class